### PR TITLE
Feat: 트렌드 페이지에서 Suspense 사용하도록 변경 및 탭 변경 로직 개선

### DIFF
--- a/src/app/trend/page.tsx
+++ b/src/app/trend/page.tsx
@@ -9,9 +9,109 @@ import {
 import { motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
 type TrendTab = "all" | "tracks" | "artists" | "albums";
+
+// useSearchParams를 사용하는 부분을 분리한 클라이언트 컴포넌트
+function TrendTabSelector({
+  activeTab,
+  onChange,
+}: {
+  activeTab: TrendTab;
+  onChange: (tab: TrendTab) => void;
+}) {
+  const searchParams = useSearchParams();
+
+  // URL에서 탭 파라미터 가져오기
+  const typeParam = (searchParams.get("type") || "all") as TrendTab;
+
+  // URL 파라미터 변경 감지 - 초기 로드 시에만 실행
+  useEffect(() => {
+    // 초기 로드 시 URL 파라미터에서 탭 설정
+    onChange(typeParam);
+  }, [typeParam, onChange]);
+
+  // 탭 변경 핸들러
+  const handleTypeChange = (type: TrendTab) => {
+    onChange(type);
+
+    // URL 파라미터 업데이트 (히스토리 API 사용)
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      if (type === "all") {
+        url.searchParams.delete("type");
+      } else {
+        url.searchParams.set("type", type);
+      }
+
+      window.history.pushState({}, "", url.toString());
+    }
+  };
+
+  return (
+    <div className="mb-4">
+      <div className="flex justify-center">
+        <div className="inline-flex gap-4 px-1">
+          <button
+            onClick={() => handleTypeChange("all")}
+            className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
+              activeTab === "all"
+                ? "text-primary font-semibold"
+                : "text-gray-500 hover:text-gray-800"
+            }`}
+          >
+            전체
+            {activeTab === "all" && (
+              <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
+            )}
+          </button>
+          <button
+            onClick={() => handleTypeChange("artists")}
+            className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
+              activeTab === "artists"
+                ? "text-primary font-semibold"
+                : "text-gray-500 hover:text-gray-800"
+            }`}
+          >
+            아티스트
+            {activeTab === "artists" && (
+              <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
+            )}
+          </button>
+          <button
+            onClick={() => handleTypeChange("tracks")}
+            className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
+              activeTab === "tracks"
+                ? "text-primary font-semibold"
+                : "text-gray-500 hover:text-gray-800"
+            }`}
+          >
+            트랙
+            {activeTab === "tracks" && (
+              <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
+            )}
+          </button>
+          <button
+            onClick={() => handleTypeChange("albums")}
+            className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
+              activeTab === "albums"
+                ? "text-primary font-semibold"
+                : "text-gray-500 hover:text-gray-800"
+            }`}
+          >
+            앨범
+            {activeTab === "albums" && (
+              <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
+            )}
+          </button>
+        </div>
+      </div>
+      <div className="w-full h-px bg-gray-200 mt-0.5"></div>
+    </div>
+  );
+}
 
 export default function TrendPage() {
   const [activeTab, setActiveTab] = useState<TrendTab>("all");
@@ -50,75 +150,14 @@ export default function TrendPage() {
     (activeTab === "albums" && albumError) ||
     (activeTab === "all" && (trackError || artistError || albumError));
 
-  // 탭 변경 핸들러
-  const handleTypeChange = (type: TrendTab) => {
-    setActiveTab(type);
-  };
-
   return (
     <>
       <Header title="트렌드" />
       <div className="py-6 space-y-6 px-4">
-        {/* 탭 선택 - 검색 페이지와 동일한 스타일 */}
-        <div className="mb-4">
-          <div className="flex justify-center">
-            <div className="inline-flex gap-4 px-1">
-              <button
-                onClick={() => handleTypeChange("all")}
-                className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
-                  activeTab === "all"
-                    ? "text-primary font-semibold"
-                    : "text-gray-500 hover:text-gray-800"
-                }`}
-              >
-                전체
-                {activeTab === "all" && (
-                  <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
-                )}
-              </button>
-              <button
-                onClick={() => handleTypeChange("artists")}
-                className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
-                  activeTab === "artists"
-                    ? "text-primary font-semibold"
-                    : "text-gray-500 hover:text-gray-800"
-                }`}
-              >
-                아티스트
-                {activeTab === "artists" && (
-                  <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
-                )}
-              </button>
-              <button
-                onClick={() => handleTypeChange("tracks")}
-                className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
-                  activeTab === "tracks"
-                    ? "text-primary font-semibold"
-                    : "text-gray-500 hover:text-gray-800"
-                }`}
-              >
-                트랙
-                {activeTab === "tracks" && (
-                  <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
-                )}
-              </button>
-              <button
-                onClick={() => handleTypeChange("albums")}
-                className={`relative py-2 px-4 font-medium text-sm transition-all duration-200 ${
-                  activeTab === "albums"
-                    ? "text-primary font-semibold"
-                    : "text-gray-500 hover:text-gray-800"
-                }`}
-              >
-                앨범
-                {activeTab === "albums" && (
-                  <div className="absolute bottom-0 left-0 w-full h-0.5 bg-primary rounded-full"></div>
-                )}
-              </button>
-            </div>
-          </div>
-          <div className="w-full h-px bg-gray-200 mt-0.5"></div>
-        </div>
+        {/* 탭 선택 - Suspense로 감싸서 useSearchParams 사용 */}
+        <Suspense fallback={<div className="mb-4 h-10" />}>
+          <TrendTabSelector activeTab={activeTab} onChange={setActiveTab} />
+        </Suspense>
 
         {/* 에러 상태 */}
         {error && (
@@ -142,7 +181,7 @@ export default function TrendPage() {
                 <div className="flex justify-between items-center">
                   <h2 className="text-xl font-bold">아티스트</h2>
                   <button
-                    onClick={() => handleTypeChange("artists")}
+                    onClick={() => setActiveTab("artists")}
                     className="text-primary hover:text-primary/80 hover:underline text-sm font-medium px-3 py-1 rounded-full transition-all duration-200"
                   >
                     더 보기
@@ -184,7 +223,7 @@ export default function TrendPage() {
                 <div className="flex justify-between items-center">
                   <h2 className="text-xl font-bold">트랙</h2>
                   <button
-                    onClick={() => handleTypeChange("tracks")}
+                    onClick={() => setActiveTab("tracks")}
                     className="text-primary hover:text-primary/80 hover:underline text-sm font-medium px-3 py-1 rounded-full transition-all duration-200"
                   >
                     더 보기
@@ -228,7 +267,7 @@ export default function TrendPage() {
                 <div className="flex justify-between items-center">
                   <h2 className="text-xl font-bold">앨범</h2>
                   <button
-                    onClick={() => handleTypeChange("albums")}
+                    onClick={() => setActiveTab("albums")}
                     className="text-primary hover:text-primary/80 hover:underline text-sm font-medium px-3 py-1 rounded-full transition-all duration-200"
                   >
                     더 보기

--- a/src/constants/spotify.ts
+++ b/src/constants/spotify.ts
@@ -32,46 +32,46 @@ export const RECOMMENDED_TRACK_IDS = [
  * 트렌드 페이지에 표시될 아티스트 ID 목록
  */
 export const TREND_ARTIST_IDS = [
-  "4YRxDV8wJFPHPTeXepOstw", // Arijit Singh
   "06HL4z0CvFAxyc27GXpf02", // Taylor Swift
-  "6eUKZXaKkcviH0Ku9w2n3V", // Ed Sheeran
+  "0du5cEVh5yTK9QJze8zA0C", // Bruno Mars
+  "1Xyo4u8uXC1ZmMpatF05PJ", // The Weeknd
   "6qqNVTkY8uBg9cP3Jd7DAH", // Billie Eilish
   "66CXWjxzNUsdJxJ2JdwvnR", // Ariana Grande
-  "1Xyo4u8uXC1ZmMpatF05PJ", // The Weeknd
-  "7dGJo4pcD2V6oG8kP0tJRR", // Eminem
-  "3TVXtAsR1Inumwj472S9r4", // Drake
+  "2YZyLoL8N0Wb9xBt1NhZWg", // Kendrick Lamar
+  "699OTQXzgjhIYAHMy9RyPD", // Playboi Carti
+  "74KM79TiuVKeVCqs8QtB0B", // Sabrina Carpenter
   "4q3ewBCX7sLwd24euuV69X", // Bad Bunny
-  "1uNFoZAHBGtllmzznpCI3s", // Justin Bieber
+  "1HY2Jd0NmPuamShAr6KMms", // Lady Gaga
 ];
 
 /**
  * 트렌드 페이지에 표시될 트랙 ID 목록
  */
 export const TREND_TRACK_IDS = [
-  "1hA697u7e1jX2XM8sWA6Uy", // Apna Bana Le - Arijit Singh
-  "1BxfuPKGuaTgP7aM0Bbdwr", // Cruel Summer - Taylor Swift
-  "0GRc3eGTg8HBdWLRGYgqIc", // Azizam - Ed Sheeran
+  "45J4avUb9Ni0bnETYaYFVJ", // luther (with sza) - Kendrick Lamar
+  "6ZWalyzfVcNCc1XwKnnyyn", // Not Like Us - Kendrick Lamar
+  "2plbrEY59IikOBgBGLjaoe", // Die With A Smile - Lady Gaga, Bruno Mars
   "6dOtVTDdiauQNBQEDOtlAB", // BIRDS OF A FEATHER - Billie Eilish
   "51ZQ1vr10ffzbwIjDCwqm4", // we can't be friends (wait for your love) - Ariana Grande
   "0FIDCNYYjNvPVimz5icugS", // Timeless (feat Playboi Carti) - The Weeknd
-  "7lQ8MOhq6IN2w8EYcFNSUk", // Without Me - Eminem
-  "2u9S9JJ6hTZS3Vf22HOZKg", // NOKIA - Drake
+  "2vDkR3ctidSd17d2CygVzS", // APT. - ROSE, Bruno Mars
+  "6qqrTXSdwiJaq8SO0X2lSe", // Ordinary - Alex Warren
   "3sK8wGT43QFpWrvNQsrQya", // DtMF - Bad Bunny
-  "6QFCMUUq1T2Vf5sFUXcuQ7", // Beauty And A Beat - Justin Bieber
+  "6iycYUk3oB0NPMdaDUrN1w", // EVIL J0RDAN - Playboi Carti
 ];
 
 /**
  * 트렌드 페이지에 표시될 앨범 ID 목록
  */
 export const TREND_ALBUM_IDS = [
-  "1pw0xzpe4O0OMohBwau50L", // Bhediya (Original Motion Picture Soundtrack) - Arijit Singh
-  "1NAmidJlEaVgA3MpcPFYGq", // Lover - Taylor Swift
-  "37HwcDtLqY2WXN7NArODvI", // Azizam - Ed Sheeran
+  "0hvT3yIEysuuvkK73vgdcW", // GNX - Kendrick Lamar
+  "0fSfkmx0tdPqFYkJuNX74a", // Music - Playboi Carti
+  "3VQkNrG74QPY4rHBPoyZYZ", // SOS Deluxe: LANA - SZA
   "7aJuG4TFXa2hmE4z1yxc3n", // HIT ME HARD AND SOFT - Billie Eilish
   "5EYKrEDnKhhcNxGedaRQeK", // eternal sunshine - Ariana Grande
   "3OxfaVgvTxUTy7276t7SPU", // Hurry Up Tomorrow - The Weeknd
-  "2cWBwpqMsDJC1ZUwz813lo", // The Eminem Show - Eminem
+  "3w32SV56JvtJXsrYtThwzP", // So Close To What - Tate McRae
   "6Rl6YoCarF2GHPSQmmFjuR", // $ome $exy $ongs 4 U - Drake
   "5K79FLRUCSysQnVESLcTdb", // DeBÍ TiRAR MáS FOToS - Bad Bunny
-  "5cxMa6oLINJzmZ8lF7wWQN", // BelieveJustin Bieber
+  "2MHUaRi9OCyTN02SoyRRBJ", // MAYHEM - Lady Gaga
 ];

--- a/src/features/search/components/ArtistResults.tsx
+++ b/src/features/search/components/ArtistResults.tsx
@@ -53,7 +53,7 @@ export const ArtistResults = ({
               {artist.name}
             </h3>
             <p className="text-sm text-text-secondary truncate text-center">
-              아티스트
+              {artist.genres?.slice(0, 2).join(", ") || "아티스트"}
             </p>
           </Link>
         ))}


### PR DESCRIPTION
1. [Feat: 트렌드 페이지에서 Suspense 사용하도록 변경 및 탭 변경 로직 개선](https://github.com/jihohub/dj-set-list/commit/63be011a5e9aaee3fc7ce0dfe61f27a4792b64fa)
2. [Feat: 검색 페이지 아티스트 결과에서 아티스트의 장르도 보여주도록 변경](https://github.com/jihohub/dj-set-list/commit/51cc9f8b9cb17ab148a9ec1c87f1089d8a319ffd)
3. [Feat: 트렌드 페이지에 표시될 상수 ID값 수정](https://github.com/jihohub/dj-set-list/commit/2f2a9769273ac79721d7d861db32d19f824eed34)