### PR TITLE
Fix: SearchBar 컴포넌트 css에서 backdrop-filter 속성 제거

### DIFF
--- a/src/features/search/SearchPage.tsx
+++ b/src/features/search/SearchPage.tsx
@@ -5,7 +5,7 @@ import BasicSearchResults from "./components/BasicSearchResults";
 import InfiniteScrollResults from "./components/InfiniteScrollResults";
 import NoResults from "./components/NoResults";
 import PopularSearches from "./components/PopularSearches";
-// import SearchHeader from "./components/SearchHeader";
+import SearchHeader from "./components/SearchHeader";
 import { useSearchPageLogic } from "./hooks/useSearchPageLogic";
 
 export function SearchPage() {
@@ -74,14 +74,14 @@ export function SearchPage() {
       id="search-page-container"
     >
       {/* 헤더 영역: 검색 입력과 탭 */}
-      {/* <SearchHeader
+      <SearchHeader
         searchTerm={searchTerm}
         searchType={searchType}
         handleSearchChange={handleSearchChange}
         clearSearch={clearSearch}
         handleSearchSubmit={handleSearchSubmit}
         handleTypeChange={handleTypeChange}
-      /> */}
+      />
 
       {/* 초기 로딩 상태 */}
       {/* <AnimatePresence mode="wait">

--- a/src/features/search/components/SearchBar.tsx
+++ b/src/features/search/components/SearchBar.tsx
@@ -45,7 +45,7 @@ export const SearchBar = ({
         initial={{ opacity: 0.8, y: -10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
-        className="relative bg-card-bg/80 backdrop-blur-md rounded-full border border-gray-200/10 px-4 py-2.5 shadow-sm"
+        className="relative bg-card-bg rounded-full border border-gray-200/10 px-4 py-2.5 shadow-sm"
         whileTap={{ scale: 0.99 }}
       >
         <div className="flex items-center">


### PR DESCRIPTION
1. [Fix: SearchBar 컴포넌트 css에서 backdrop-filter 속성 제거](https://github.com/jihohub/dj-set-list/commit/c56d4e4b2a87a02124cfd6be1cb3965cfde98df4)