### PR TITLE
Fix: ExplicitBadge 컴포넌트에서 className 제거

### DIFF
--- a/src/features/album/components/AlbumHeader.tsx
+++ b/src/features/album/components/AlbumHeader.tsx
@@ -55,9 +55,7 @@ export const AlbumHeader = ({ album }: AlbumHeaderProps) => {
                 <h1 className="text-xl sm:text-2xl md:text-3xl lg:text-5xl font-bold">
                   {album.name}
                 </h1>
-                {album.explicit && (
-                  <ExplicitBadge className="ml-2 flex-shrink-0" />
-                )}
+                {album.explicit && <ExplicitBadge />}
               </div>
               <div className="flex flex-wrap gap-2 mt-3">
                 {album.artists.map((albumArtist, index) => (

--- a/src/features/artist/components/TopTracks.tsx
+++ b/src/features/artist/components/TopTracks.tsx
@@ -52,9 +52,7 @@ export const TopTracks = ({ tracks }: TopTracksProps) => {
                 >
                   {track.name}
                 </Link>
-                {track.explicit && (
-                  <ExplicitBadge className="ml-1 flex-shrink-0" />
-                )}
+                {track.explicit && <ExplicitBadge />}
               </div>
             </div>
             <div className="hidden md:block w-1/4 min-w-0">

--- a/src/features/new/components/NewReleaseGrid.tsx
+++ b/src/features/new/components/NewReleaseGrid.tsx
@@ -90,9 +90,7 @@ export const NewReleaseGrid = ({
             </div>
             <div className="mt-2 flex items-center gap-1">
               <h3 className="font-semibold truncate">{album.name}</h3>
-              {album.explicit && (
-                <ExplicitBadge className="ml-1 flex-shrink-0" />
-              )}
+              {album.explicit && <ExplicitBadge />}
             </div>
             <p className="text-sm text-text-secondary truncate">
               {album.artists?.map((a) => a.name).join(", ")}

--- a/src/features/search/components/AlbumResults.tsx
+++ b/src/features/search/components/AlbumResults.tsx
@@ -60,9 +60,7 @@ export const AlbumResults = ({
               </div>
               <div className="mt-2 flex items-center gap-1">
                 <h3 className="font-semibold truncate">{album.name}</h3>
-                {album.explicit && (
-                  <ExplicitBadge className="ml-1 flex-shrink-0" />
-                )}
+                {album.explicit && <ExplicitBadge />}
               </div>
               <p className="text-sm text-text-secondary truncate">
                 {album.artists.map((a) => a.name).join(", ")}

--- a/src/features/search/components/TrackResults.tsx
+++ b/src/features/search/components/TrackResults.tsx
@@ -60,9 +60,7 @@ export const TrackResults = ({
               </div>
               <div className="mt-2 flex items-center gap-1">
                 <h3 className="font-semibold truncate">{track.name}</h3>
-                {track.explicit && (
-                  <ExplicitBadge className="ml-1 flex-shrink-0" />
-                )}
+                {track.explicit && <ExplicitBadge />}
               </div>
               <p className="text-sm text-text-secondary truncate">
                 {track.artists.map((a) => a.name).join(", ")}

--- a/src/features/track/components/TrackHeader.tsx
+++ b/src/features/track/components/TrackHeader.tsx
@@ -55,9 +55,7 @@ export const TrackHeader = ({ track }: TrackHeaderProps) => {
                 <h1 className="text-xl sm:text-2xl md:text-3xl lg:text-5xl font-bold">
                   {track.name}
                 </h1>
-                {track.explicit && (
-                  <ExplicitBadge className="ml-2 flex-shrink-0" />
-                )}
+                {track.explicit && <ExplicitBadge />}
               </div>
               <div className="flex flex-wrap gap-2 mt-3">
                 {track.artists.map((trackArtist, index) => (

--- a/src/features/trend/components/AlbumGrid.tsx
+++ b/src/features/trend/components/AlbumGrid.tsx
@@ -59,9 +59,7 @@ export const AlbumGrid = ({
               </div>
               <div className="mt-2 flex items-center gap-1">
                 <h3 className="font-semibold truncate text-sm">{album.name}</h3>
-                {album.explicit && (
-                  <ExplicitBadge className="ml-1 flex-shrink-0" />
-                )}
+                {album.explicit && <ExplicitBadge />}
               </div>
               <p className="text-sm text-text-secondary truncate">
                 {album.artists.map((a) => a.name).join(", ")}

--- a/src/features/trend/components/TrackList.tsx
+++ b/src/features/trend/components/TrackList.tsx
@@ -59,9 +59,7 @@ export const TrackList = ({
               </div>
               <div className="mt-2 flex items-center gap-1">
                 <h3 className="font-semibold truncate text-sm">{track.name}</h3>
-                {track.explicit && (
-                  <ExplicitBadge className="ml-1 flex-shrink-0" />
-                )}
+                {track.explicit && <ExplicitBadge />}
               </div>
               <p className="text-sm text-text-secondary truncate">
                 {track.artists.map((a) => a.name).join(", ")}


### PR DESCRIPTION
1. [Fix: ExplicitBadge 컴포넌트에서 className 제거](https://github.com/jihohub/dj-set-list/commit/8cb77e6c1ee394bd018ff800dc450a4a2c13145e)